### PR TITLE
fixes #4: Allow Spark games to be disabled.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,12 @@
 <h1>
 Client Control Plugin Changelog
 </h1>
+
+<p><b>2.1.6</b> -- (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-clientControl-plugin/issues/4'>Issue #4</a>] - Add option to disable selected plugins in Spark (requires Spark 2.9.4 or later)</li>
+</ul>
+
 <p><b>2.1.5</b> -- August 17, 2020</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1452'>OF-1452</a>] - Add Russian translation</li>

--- a/src/i18n/clientcontrol_i18n.properties
+++ b/src/i18n/clientcontrol_i18n.properties
@@ -126,7 +126,10 @@ client.features.hostnameasresource               = Hostname as Resource
 client.features.hostnameasresource.description   = Use computer's hostname as resource (shouldn't be used along with "Version As Resource").
 client.features.versionasresource                = Version as Resource
 client.features.versionasresource.description    = Use Spark version as resource (shouldn't be used along with "Hostname As Resource").
-
+client.features.sparkPluginReversiEnabled               = Reversi Game
+client.features.sparkPluginReversiEnabled.description   = Allow users to play the game "Reversi".
+client.features.sparkPluginTicTacToeEnabled             = TicTacToe Game
+client.features.sparkPluginTicTacToeEnabled.description = Allow users to play the game "TicTacToe".
 permitted.client.title = Permitted Clients
 permitted.client.description =  Use the form below to restrict client access.
 permitted.client.success = Client version settings have been updated.

--- a/src/web/client-features.jsp
+++ b/src/web/client-features.jsp
@@ -6,6 +6,9 @@
 <%@ page import="org.jivesoftware.util.CookieUtils" %>
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.openfire.plugin.ClientControlPlugin" %>
+<%@ page import="java.util.Collections" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -103,6 +106,14 @@
         hostnameasresourceEnabledString = request.getParameter("hostnameasresourceEnabled");
         versionasresourceEnabledString = request.getParameter("versionasresourceEnabled");
 
+        final List<String> blackListedPlugins = new ArrayList<>();
+        if ( !Boolean.parseBoolean( request.getParameter("sparkPluginReversiEnabled")) ) {
+            blackListedPlugins.add("Reversi");
+        }
+        if ( !Boolean.parseBoolean( request.getParameter("sparkPluginTicTacToeEnabled")) ) {
+            blackListedPlugins.add("TicTacToe");
+        }
+
         JiveGlobals.setProperty("accounts.enabled", accountsEnabledString);
         JiveGlobals.setProperty("addcontacts.enabled", addcontactsEnabledString);
         JiveGlobals.setProperty("addgroups.enabled", addgroupsEnabledString);
@@ -134,6 +145,7 @@
         JiveGlobals.setProperty("startachat.enabled", startachatEnabledString);
         JiveGlobals.setProperty("hostnameasresource.enabled", hostnameasresourceEnabledString);
         JiveGlobals.setProperty("versionasresource.enabled", versionasresourceEnabledString);
+        JiveGlobals.setProperty("sparkplugin.blacklist", blackListedPlugins);
     }
     
     boolean accountsEnabled = Boolean.parseBoolean(accountsEnabledString);
@@ -167,7 +179,11 @@
     boolean startachatEnabled = Boolean.parseBoolean(startachatEnabledString);
     boolean hostnameasresourceEnabled = Boolean.parseBoolean(hostnameasresourceEnabledString);
     boolean versionasresourceEnabled = Boolean.parseBoolean(versionasresourceEnabledString);
-        
+
+    final List<String> blacklistedPlugins = JiveGlobals.getListProperty("sparkplugin.blacklist", new ArrayList<String>());
+    boolean sparkPluginReversiEnabled = !blacklistedPlugins.contains("Reversi");
+    boolean sparkPluginTicTacToeEnabled = !blacklistedPlugins.contains("TicTacToe");
+
     // Enable File Transfer in the system.
     ClientControlPlugin plugin = (ClientControlPlugin) XMPPServer.getInstance()
             .getPluginManager().getPlugin("clientcontrol");
@@ -557,6 +573,28 @@
                 </td>
                 <td width="1%" nowrap>
                     <input type="radio" name="versionasresourceEnabled" value="false" <%= !versionasresourceEnabled ? "checked" : "" %> />
+                </td>
+            </tr>
+            <tr>
+                <td><b><fmt:message key="client.features.sparkPluginReversiEnabled" /></b> - <fmt:message key="client.features.spark.only" /><br/><span class="jive-description">
+                         <fmt:message key="client.features.sparkPluginReversiEnabled.description" />
+                      </span></td>
+                <td width="1%" nowrap>
+                    <input type="radio" name="sparkPluginReversiEnabled" value="true" <%= sparkPluginReversiEnabled ? "checked" : "" %> />
+                </td>
+                <td width="1%" nowrap>
+                    <input type="radio" name="sparkPluginReversiEnabled" value="false" <%= !sparkPluginReversiEnabled ? "checked" : "" %> />
+                </td>
+            </tr>
+            <tr>
+                <td><b><fmt:message key="client.features.sparkPluginTicTacToeEnabled" /></b> - <fmt:message key="client.features.spark.only" /><br/><span class="jive-description">
+                         <fmt:message key="client.features.sparkPluginTicTacToeEnabled.description" />
+                      </span></td>
+                <td width="1%" nowrap>
+                    <input type="radio" name="sparkPluginTicTacToeEnabled" value="true" <%= sparkPluginTicTacToeEnabled ? "checked" : "" %> />
+                </td>
+                <td width="1%" nowrap>
+                    <input type="radio" name="sparkPluginTicTacToeEnabled" value="false" <%= !sparkPluginTicTacToeEnabled ? "checked" : "" %> />
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Adds functionality that allows Spark to detect what plugins it should add to its blacklist.

Applies this functionality to two plugins: Reversi and TicTacToe.

This requires changes that will likely go in Spark version 2.9.4. Related Spark changes in https://github.com/igniterealtime/Spark/pull/556