### PR TITLE
Client Control can't identify Spark since 2.8.0 version

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -45,6 +45,7 @@ Client Control Plugin Changelog
 </h1>
 
 <p><b>2.1.8</b> -- T.B.D.</p>
+	<li>[<a href='https://github.com/igniterealtime/openfire-clientControl-plugin/issues/5'>Issue #5</a>] - Client Control can't identify Spark since 2.8.0 version(requires Spark 2.9.0 or later)</li>
 <ul>
 </ul>
 


### PR DESCRIPTION
This appears to have been fixed back in Spark 2.9.0. Also I checked in the latest nightly build of Spark 3.0.0 It works!)
![2022-08-29_20-52-13](https://user-images.githubusercontent.com/71222850/187266494-639f823d-596b-4679-97cb-6de23e199d9f.png)
