### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,7 +46,10 @@ Client Control Plugin Changelog
 
 <p><b>2.1.9</b> TBD</p>
 <ul>
+    <li>Requires Openfire 4.8.0 or later.</li>
     <li>Bump commons-fileupload from 1.4 to 1.5.</li>
+    <li>Update of Chinese translation</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-clientControl-plugin/issues/46'>Issue #46</a>] - Compatible with Openfire 4.9.0</li>
 </ul>
 
 <p><b>2.1.8</b> -- August 30, 2022</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,9 +9,8 @@
     <description>Controls clients allowed to connect and available features</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
-    <date>2022-08-30</date>
-    <minServerVersion>4.0.0</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <date>2024-09-11</date>
+    <minServerVersion>4.8.0</minServerVersion>
 
     <!-- UI extension -->
     <adminconsole>		

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.8.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>clientControl</artifactId>
@@ -21,14 +21,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-jspc-maven-plugin</artifactId>
-                <version>9.2.14.v20151106</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.igniterealtime.openfire</groupId>
-                        <artifactId>xmppserver</artifactId>
-                        <version>${openfire.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/java/org/jivesoftware/openfire/plugin/ClientControlPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/ClientControlPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008 Jive Software. All rights reserved.
+ * Copyright (C) 2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,8 @@ import org.jivesoftware.openfire.plugin.spark.SparkManager;
 import org.jivesoftware.openfire.plugin.spark.TaskEngine;
 import org.jivesoftware.openfire.plugin.spark.manager.SparkVersionManager;
 import org.jivesoftware.openfire.plugin.spark.manager.FileTransferFilterManager;
-import org.jivesoftware.util.JiveGlobals;
 
 import java.io.File;
-import java.io.FileFilter;
 
 /**
  * Client control plugin.
@@ -48,20 +46,6 @@ public class ClientControlPlugin implements Plugin {
     // Plugin Interface
 
     public void initializePlugin(PluginManager manager, File pluginDirectory) {
-        // Check if we Enterprise is installed and stop loading this plugin if found
-        File pluginDir = new File(JiveGlobals.getHomeDirectory(), "plugins");
-        File[] jars = pluginDir.listFiles(new FileFilter() {
-            public boolean accept(File pathname) {
-                String fileName = pathname.getName().toLowerCase();
-                return (fileName.equalsIgnoreCase("enterprise.jar"));
-            }
-        });
-        if (jars.length > 0) {
-            // Do not load this plugin since Enterprise is still installed
-            System.out.println("Enterprise plugin found. Stopping Client Control Plugin");
-            throw new IllegalStateException("This plugin cannot run next to the Enterprise plugin");
-        }
-
         taskEngine = TaskEngine.getInstance();
         sparkManager = new SparkManager(taskEngine);
         sparkManager.start();

--- a/src/web/spark-download.jsp
+++ b/src/web/spark-download.jsp
@@ -2,6 +2,8 @@
 <%@ page import="org.jivesoftware.openfire.XMPPServer" %>
 <%@ page import="org.jivesoftware.util.JiveGlobals" %>
 <%@ page import="java.io.File" %>
+<%@ page import="java.nio.file.Path" %>
+<%@ page import="java.nio.file.Files" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
@@ -29,9 +31,10 @@
     boolean windowsClientExists = false;
     boolean macClientExists = false;
     boolean linuxClientExists = false;
-    File buildDir = new File(JiveGlobals.getHomeDirectory(), "enterprise" + File.separator + "spark");
-    if (buildDir.exists()) {
-        File[] list = buildDir.listFiles();
+
+    Path buildDir = JiveGlobals.getHomePath().resolve("enterprise").resolve("spark");
+    if (Files.exists(buildDir)) {
+        File[] list = buildDir.toFile().listFiles();
         int no = list != null ? list.length : 0;
         for (int i = 0; i < no; i++) {
             File clientFile = list[i];


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #46