### PR TITLE
fixes #51: Compatible with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Client Control Plugin Changelog
 
 <p><b>2.1.10</b> (To be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-clientControl-plugin/issues/51'>Issue #51</a>] - Compatible with Openfire 5.0.0</li>
 </ul>
 
 <p><b>2.1.9</b> September 12, 2024</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <description>Controls clients allowed to connect and available features</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
-    <date>2024-09-12</date>
+    <date>2025-06-24</date>
     <minServerVersion>4.8.0</minServerVersion>
 
     <!-- UI extension -->

--- a/src/web/client-features.jsp
+++ b/src/web/client-features.jsp
@@ -226,7 +226,7 @@
 	
     // Enable File Transfer in the system.
     ClientControlPlugin plugin = (ClientControlPlugin) XMPPServer.getInstance()
-            .getPluginManager().getPlugin("clientcontrol");
+            .getPluginManager().getPluginByName("Client Control").orElseThrow();
     FileTransferFilterManager manager = plugin.getFileTransferFilterManager();
     manager.enableFileTransfer(transferEnabled);
 %>


### PR DESCRIPTION
This replaces usage of Openfire API that was dropped in 5.0.0 with API that was introduced in 4.4.0.

As a result, the plugin should now be compatible with Openfire 5.0.0 (while it retains compatibility with Openfire 4.8.0).